### PR TITLE
Fix Jod Data metabox save

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ You can find extensive documentation on [how to install plugins](http://codex.wo
 
 == Changelog ==
 
+= 0.2.1 =
+* Fix: Saving the Job Data meta box now calls correct action, so changes are saved
+
 = 0.2.0 =
 * Public testing release is now available
 

--- a/src/Admin/Metaboxes/JobDetails.php
+++ b/src/Admin/Metaboxes/JobDetails.php
@@ -179,7 +179,7 @@ class JobDetails extends Metabox
 		if ( ! current_user_can( 'edit_post', $post_id ) ) return;
 		if ( $post->post_type != 'job_listing' ) return;
 
-		do_action( 'listings_job_save_job_listing', $post_id, $post );
+		do_action( 'listings_jobs_save_job_listing', $post_id, $post );
 	}
 
 	/**


### PR DESCRIPTION
Minor typo in calling action that resulted in not saving of the jobs meta data when edited in admin panel.